### PR TITLE
Refactor: detection based on ShapeBpmnElementKind enum only

### DIFF
--- a/docs/bpmn-support-how-to.adoc
+++ b/docs/bpmn-support-how-to.adoc
@@ -1,0 +1,19 @@
+= BPMN Support - How To
+
+== Elements detection
+
+Except for special container elements like `Pool`, `Lane` and `Subprocess`, detecting a BPMN elements only requires to
+add a new value in the `ShapeBpmnElementKind` enum.
+
+The `ShapeModelConverter` uses the `ShapeBpmnElementKind` values to detect elements in the BPMN source.
+
+
+== Elements rendering
+
+When inserting an element on the graph, a style is passed to identify the way it will be rendered.
+
+The https://jgraph.github.io/mxgraph/docs/js-api/files/view/mxStylesheet-js.html[style] is registered in `MxGraphConfigurator`
+In particular, it refers to the name of a https://jgraph.github.io/mxgraph/docs/js-api/files/shape/mxShape-js.html[mxShape]
+used for the rendering.
+
+Custom BPMN shapes are also register by the `MxGraphConfigurator`

--- a/docs/bpmn-support-how-to.adoc
+++ b/docs/bpmn-support-how-to.adoc
@@ -2,10 +2,13 @@
 
 == Elements detection
 
-Except for special container elements like `Pool`, `Lane` and `Subprocess`, detecting a BPMN elements only requires to
+Except for special container elements like `Pool`, `Lane` and `Subprocess`, detecting a new BPMN element only requires to
 add a new value in the `ShapeBpmnElementKind` enum.
 
 The `ShapeModelConverter` uses the `ShapeBpmnElementKind` values to detect elements in the BPMN source.
+
+*Important*: do not forget to add parsing (xml and json) tests related to the new BPMN element to ensure that the parser
+is able to make it available to the `ShapeModelConverter`
 
 
 == Elements rendering

--- a/src/component/parser/json/converter/ShapeModelConverter.ts
+++ b/src/component/parser/json/converter/ShapeModelConverter.ts
@@ -6,6 +6,10 @@ import { ShapeBpmnElementKind } from '../../../../model/bpmn/shape/ShapeBpmnElem
 const convertedFlowNodeBpmnElements: ShapeBpmnElement[] = [];
 const convertedLaneBpmnElements: ShapeBpmnElement[] = [];
 
+const flowNodeKinds = Object.values(ShapeBpmnElementKind).filter(kind => {
+  return kind != ShapeBpmnElementKind.LANE;
+});
+
 export function findFlowNodeBpmnElement(id: string): ShapeBpmnElement {
   return convertedFlowNodeBpmnElements.find(i => i.id === id);
 }
@@ -47,12 +51,11 @@ export default class ShapeModelConverter extends AbstractConverter<ShapeBpmnElem
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  parseProcess(process: { [index: string]: any; startEvent: any; userTask: any; lane: any; laneSet: any }): void {
-    this.buildFlowNodeBpmnElement(process[ShapeBpmnElementKind.EVENT_START], ShapeBpmnElementKind.EVENT_START);
-    this.buildFlowNodeBpmnElement(process[ShapeBpmnElementKind.TASK_USER], ShapeBpmnElementKind.TASK_USER);
-
-    this.buildLaneBpmnElement(process.lane);
-    this.buildLaneSetBpmnElement(process.laneSet);
+  parseProcess(process: { [index: string]: any }): void {
+    flowNodeKinds.forEach(kind => this.buildFlowNodeBpmnElement(process[kind], kind));
+    // containers
+    this.buildLaneBpmnElement(process[ShapeBpmnElementKind.LANE]);
+    this.buildLaneSetBpmnElement(process['laneSet']);
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/component/parser/json/converter/ShapeModelConverter.ts
+++ b/src/component/parser/json/converter/ShapeModelConverter.ts
@@ -47,9 +47,9 @@ export default class ShapeModelConverter extends AbstractConverter<ShapeBpmnElem
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  parseProcess(process: { startEvent: any; userTask: any; lane: any; laneSet: any }): void {
-    this.buildFlowNodeBpmnElement(process.startEvent, ShapeBpmnElementKind.EVENT_START);
-    this.buildFlowNodeBpmnElement(process.userTask, ShapeBpmnElementKind.TASK_USER);
+  parseProcess(process: { [index: string]: any; startEvent: any; userTask: any; lane: any; laneSet: any }): void {
+    this.buildFlowNodeBpmnElement(process[ShapeBpmnElementKind.EVENT_START], ShapeBpmnElementKind.EVENT_START);
+    this.buildFlowNodeBpmnElement(process[ShapeBpmnElementKind.TASK_USER], ShapeBpmnElementKind.TASK_USER);
 
     this.buildLaneBpmnElement(process.lane);
     this.buildLaneSetBpmnElement(process.laneSet);

--- a/src/model/bpmn/shape/ShapeBpmnElementKind.ts
+++ b/src/model/bpmn/shape/ShapeBpmnElementKind.ts
@@ -6,6 +6,6 @@
  */
 export enum ShapeBpmnElementKind {
   LANE = 'lane',
-  TASK_USER = 'user',
-  EVENT_START = 'start',
+  TASK_USER = 'userTask',
+  EVENT_START = 'startEvent',
 }

--- a/src/model/bpmn/shape/ShapeBpmnElementKind.ts
+++ b/src/model/bpmn/shape/ShapeBpmnElementKind.ts
@@ -1,3 +1,9 @@
+/**
+ * Describes kind of Bpmn elements.
+ *
+ * Values are the same as in the BPMN MODEL namespace (http://www.omg.org/spec/BPMN/20100524/MODEL) to allow automatic
+ * detection of elements in the BPMN source.
+ */
 export enum ShapeBpmnElementKind {
   LANE = 'lane',
   TASK_USER = 'user',


### PR DESCRIPTION
This change will simplify work to do to support new BPMN element types.
Previously, we had to modify the `ShapeModelConverter` in addition to the `ShapeBpmnElementKind` enum. The enum change is mandatory because this is how we identify the element for rendering.
But having to change the converter was a pain and led to code duplication.

The converter now generically considers all elements of the enum to apply the conversion. The BPMN containers (lane for instance) are still managed manually as they require a dedicated processing.

Also introduce a new doc which explains briefly how to support a new BPMN element type.