### PR TITLE
Refactor: jsonConvert as singleton

### DIFF
--- a/src/component/parser/json/BpmnJsonParser.ts
+++ b/src/component/parser/json/BpmnJsonParser.ts
@@ -1,12 +1,12 @@
-import { JsonConvert, OperationMode } from 'json2typescript';
 import { Definitions } from './Definitions';
 import BpmnModel from '../../../model/bpmn/BpmnModel';
+import { JsonConvert } from 'json2typescript';
+import JsonParser from './JsonParser';
 
 export default class BpmnJsonParser {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   public static parse(json: any): BpmnModel {
-    const jsonConvert: JsonConvert = new JsonConvert();
-    jsonConvert.operationMode = OperationMode.ENABLE;
+    const jsonConvert: JsonConvert = JsonParser.getInstance().jsonConvert;
     const definitions = jsonConvert.deserializeObject(json.definitions, Definitions);
 
     return definitions.bpmnModel;

--- a/src/component/parser/json/JsonParser.ts
+++ b/src/component/parser/json/JsonParser.ts
@@ -1,0 +1,39 @@
+import { JsonConvert, OperationMode, ValueCheckingMode } from 'json2typescript';
+
+/**
+ * The Singleton class defines the `getInstance` method that lets clients access
+ * the unique singleton instance.
+ */
+export default class JsonParser {
+  private static instance: JsonParser;
+  private readonly _jsonConvert: JsonConvert;
+
+  /**
+   * The Singleton's constructor should always be private to prevent direct
+   * construction calls with the `new` operator.
+   */
+  private constructor() {
+    this._jsonConvert = new JsonConvert();
+    this._jsonConvert.operationMode = OperationMode.ENABLE;
+    this._jsonConvert.ignorePrimitiveChecks = false; // don't allow assigning number to string etc.
+    this._jsonConvert.valueCheckingMode = ValueCheckingMode.DISALLOW_NULL; // never allow null
+  }
+
+  /**
+   * The static method that controls the access to the singleton instance.
+   *
+   * This implementation let you subclass the Singleton class while keeping
+   * just one instance of each subclass around.
+   */
+  public static getInstance(): JsonParser {
+    if (!JsonParser.instance) {
+      JsonParser.instance = new JsonParser();
+    }
+
+    return JsonParser.instance;
+  }
+
+  public get jsonConvert(): JsonConvert {
+    return this._jsonConvert;
+  }
+}

--- a/src/component/parser/json/converter/DiagramConverter.ts
+++ b/src/component/parser/json/converter/DiagramConverter.ts
@@ -1,4 +1,4 @@
-import { JsonConvert, JsonConverter, OperationMode, ValueCheckingMode } from 'json2typescript';
+import { JsonConvert, JsonConverter } from 'json2typescript';
 import { AbstractConverter, ensureIsArray } from './AbstractConverter';
 import Shape from '../../../../model/bpmn/shape/Shape';
 import Bounds from '../../../../model/bpmn/Bounds';
@@ -6,14 +6,7 @@ import ShapeBpmnElement from '../../../../model/bpmn/shape/ShapeBpmnElement';
 import Edge from '../../../../model/bpmn/edge/Edge';
 import BpmnModel, { Shapes } from '../../../../model/bpmn/BpmnModel';
 import { findFlowNodeBpmnElement, findLaneBpmnElement } from './SemanticConverter';
-
-//////////////////////////////////////////////////////////////
-// TODO : To move in a singleton object to use here and in the BpmnJsonParser
-const jsonConvert: JsonConvert = new JsonConvert();
-jsonConvert.operationMode = OperationMode.ENABLE;
-jsonConvert.ignorePrimitiveChecks = false; // don't allow assigning number to string etc.
-jsonConvert.valueCheckingMode = ValueCheckingMode.DISALLOW_NULL; // never allow null
-//////////////////////////////////////////////////////////////
+import JsonParser from '../JsonParser';
 
 @JsonConverter
 export default class DiagramConverter extends AbstractConverter<BpmnModel> {
@@ -64,13 +57,17 @@ export default class DiagramConverter extends AbstractConverter<BpmnModel> {
     const bpmnElement = findShapeElement(shape.bpmnElement);
     if (bpmnElement) {
       const id = shape.id;
+
+      const jsonConvert: JsonConvert = JsonParser.getInstance().jsonConvert;
       const bounds = jsonConvert.deserializeObject(shape.Bounds, Bounds);
+
       return new Shape(id, bpmnElement, bounds);
     }
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private deserializeEdges(edges: any): Edge[] {
+    const jsonConvert: JsonConvert = JsonParser.getInstance().jsonConvert;
     return jsonConvert.deserializeArray(ensureIsArray(edges), Edge);
   }
 }

--- a/src/component/parser/json/converter/SemanticConverter.ts
+++ b/src/component/parser/json/converter/SemanticConverter.ts
@@ -1,9 +1,10 @@
-import { JsonConvert, JsonConverter, OperationMode, ValueCheckingMode } from 'json2typescript';
+import { JsonConvert, JsonConverter } from 'json2typescript';
 import { AbstractConverter, ensureIsArray } from './AbstractConverter';
 import ShapeBpmnElement from '../../../../model/bpmn/shape/ShapeBpmnElement';
 import { ShapeBpmnElementKind } from '../../../../model/bpmn/shape/ShapeBpmnElementKind';
 import { Semantic } from '../Definitions';
 import SequenceFlow from '../../../../model/bpmn/edge/SequenceFlow';
+import JsonParser from '../JsonParser';
 
 const convertedFlowNodeBpmnElements: ShapeBpmnElement[] = [];
 const convertedLaneBpmnElements: ShapeBpmnElement[] = [];
@@ -24,13 +25,6 @@ export function findLaneBpmnElement(id: string): ShapeBpmnElement {
 export function findSequenceFlow(id: string): SequenceFlow {
   return convertedSequenceFlows.find(i => i.id === id);
 }
-
-// TODO : To move in a singleton object to use here and in the BpmnJsonParser
-const jsonConvert: JsonConvert = new JsonConvert();
-jsonConvert.operationMode = OperationMode.ENABLE;
-jsonConvert.ignorePrimitiveChecks = false; // don't allow assigning number to string etc.
-jsonConvert.valueCheckingMode = ValueCheckingMode.DISALLOW_NULL; // never allow null
-//////////////////////////////////////////////////////////////
 
 @JsonConverter
 export default class SemanticConverter extends AbstractConverter<Semantic> {
@@ -102,6 +96,7 @@ export default class SemanticConverter extends AbstractConverter<Semantic> {
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private buildSequenceFlow(bpmnElements: Array<any> | any): void {
+    const jsonConvert: JsonConvert = JsonParser.getInstance().jsonConvert;
     const t = jsonConvert.deserializeArray(ensureIsArray(bpmnElements), SequenceFlow);
     convertedSequenceFlows.push(...t);
   }


### PR DESCRIPTION
Move jsonConvert configuration in a singleton in order to not duplicate instantiation & configuration