### PR TITLE
[INFRA] fix license declaration in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "Javascript lib to visualize BPMN diagrams",
   "repository": "https://github.com/bonitasoft-labs/bpmn-visu-js",
-  "license": "Apache 2.0",
+  "license": "Apache-2.0",
   "module": "dist/index.es.js",
   "files": [
     "dist"


### PR DESCRIPTION
This was causing a npm warning
npm WARN bpmn-visu-js@0.1.0 license should be a valid SPDX license expression