### PR TITLE
Refactor: the Json Parser Process object is now an empty type

### DIFF
--- a/src/component/parser/json/Definitions.ts
+++ b/src/component/parser/json/Definitions.ts
@@ -13,9 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import ShapeBpmnElement from '../../../model/bpmn/shape/ShapeBpmnElement';
 import { JsonObject, JsonProperty } from 'json2typescript';
-import SequenceFlow from '../../../model/bpmn/edge/SequenceFlow';
 import BpmnModel from '../../../model/bpmn/BpmnModel';
 import DiagramConverter from './converter/DiagramConverter';
 import ProcessConverter from './converter/ProcessConverter';
@@ -44,10 +42,9 @@ export class Definitions {
   }
 }
 
-export interface Process {
-  shapeBpmnElements: ShapeBpmnElement[];
-  sequenceFlows: SequenceFlow[];
-}
+// only define a type to fill data used to build the BpmnModel
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface Process {}
 
 // only define a type to fill data used to build the BpmnModel
 // eslint-disable-next-line @typescript-eslint/no-empty-interface

--- a/src/component/parser/json/converter/ProcessConverter.ts
+++ b/src/component/parser/json/converter/ProcessConverter.ts
@@ -60,10 +60,7 @@ export default class ProcessConverter extends AbstractConverter<Process> {
 
       ensureIsArray(processes).forEach(process => this.parseProcess(process));
 
-      const sequenceFlows = convertedSequenceFlows;
-      const shapeBpmnElements = convertedLaneBpmnElements.concat(convertedLaneBpmnElements);
-
-      return { shapeBpmnElements, sequenceFlows };
+      return {};
     } catch (e) {
       // TODO error management
       console.log(e as Error);


### PR DESCRIPTION
The content of the Process is never used, as parsing the Process is only
required to fill the data structure used by `DiagramConverter` to create the
final BpmnModel
So we kept useless data during the parsing.

Closes #125