### PR TITLE
[INFRA] build gh wf: use 'npm ci' instead of 'npm install'

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
           node --version
           npm --version
       - name: Install dependencies
-        run: npm install
+        run: npm ci
       - name: Lint check
         run: npm run lint-check
       - name: Build Application

--- a/test/e2e/View.test.ts
+++ b/test/e2e/View.test.ts
@@ -122,13 +122,10 @@ describe('BPMN Visu JS', () => {
   let graph: Graph;
 
   beforeAll(async () => {
+    jest.setTimeout(20_000); // give a try to fix #154 (must be greater than the server timeout)
     await page.goto('http://localhost:10001');
     await page.waitForSelector('#graph');
     graph = new Graph(window.document.getElementById('graph'));
-  });
-
-  beforeEach(() => {
-    jest.setTimeout(100000);
   });
 
   it('should display page title', async () => {

--- a/test/e2e/View.test.ts
+++ b/test/e2e/View.test.ts
@@ -122,10 +122,13 @@ describe('BPMN Visu JS', () => {
   let graph: Graph;
 
   beforeAll(async () => {
-    jest.setTimeout(20_000); // give a try to fix #154 (must be greater than the server timeout)
     await page.goto('http://localhost:10001');
     await page.waitForSelector('#graph');
     graph = new Graph(window.document.getElementById('graph'));
+  });
+
+  beforeEach(() => {
+    jest.setTimeout(100000);
   });
 
   it('should display page title', async () => {


### PR DESCRIPTION
https://docs.npmjs.com/cli/ci documentation
This command is similar to npm-install, except it’s meant to be used in
automated environments such as test platforms, continuous integration, and
deployment.