### PR TITLE
[INFRA] build gh workflow: temporarily disable e2e tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,6 +42,7 @@ jobs:
         run: npm run build
       - name: Test Application
         run: npm run test
-      - name: Test Application End to End
-        if: matrix.os.name != 'windows-latest'
-        run: npm run e2e
+      # TODO reactivate as part of #154
+      # - name: Test Application End to End
+        # if: matrix.os.name != 'windows-latest'
+        # run: npm run e2e


### PR DESCRIPTION
They are generating false positives because of jest timeout.
This currently makes all commits marked as 'build failed' so until we fix the
issue, disable the tests.

Covers #154 